### PR TITLE
updated gogs-custom-config mountPath to correct path

### DIFF
--- a/cicd-template-with-sonar.yaml
+++ b/cicd-template-with-sonar.yaml
@@ -439,7 +439,7 @@ objects:
           - name: gogs-config
             mountPath: /etc/gogs/conf
           - name: gogs-custom-config
-            mountPath: /etc/gogs/conf
+            mountPath: /opt/gogs/custom/conf
         volumes:
           - name: gogs-data
             persistentVolumeClaim:


### PR DESCRIPTION
When using the ocp-3.5 branch with the cicd-template-with-sonar.yaml file, the Gogs pod fails to be created due to this error: `The DeploymentConfig "gogs" is invalid: spec.template.spec.containers[0].volumeMounts[2].mountPath: Invalid value: "/etc/gogs/conf": must be unique`.  I have updated this path to the same mountPath found in the ocp-3.6 cicd-template-with-sonar.yaml file.  The updated path `/opt/gogs/custom/conf` does work as expected and verified by deploying to OCP 3.5 cluster and all pods deployed successfully and are available.