### PR TITLE
Update README.md for Che git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Configure you name and email to be stamped on your Git commity by going to **Pro
 
 ![](images/che-configure-git-name.png?raw=true)
 
-Follow the steps 6-10 in the above guide to edit the code in your workspace. 
+Follow the steps 6-10 in the above guide (excluding steps to push code to Git) to edit the code in your workspace. Then continue to follow the steps below.
 
 ![](images/che-edit-file.png?raw=true)
 


### PR DESCRIPTION
Added details to clarify that within steps 6-10, any mentions regarding `git push` should be ignored as this is not possible using Che (as Gogs instance does not support OAuth or SSH). New users could spend considerable time troubleshooting the git error in Che having followed the instructions exactly.