### PR TITLE
Update template to fix error with CHE using nightly

### DIFF
--- a/cicd-template.yaml
+++ b/cicd-template.yaml
@@ -368,6 +368,7 @@ objects:
               oc process -f https://raw.githubusercontent.com/minishift/minishift/master/addons/che/templates/che-server-template.yaml \
                 --param ROUTING_SUFFIX=$HOSTNAME \
                 --param CHE_MULTIUSER=false \
+                --param CHE_VERSION="6.19.0" \
                 --param CHE_INFRA_OPENSHIFT_PROJECT=$CICD_NAMESPACE \
                 --param CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME=che-workspace | oc create -f -
 


### PR DESCRIPTION
Nightly releases of Che (the default in the template) does not work, so fixing this to the specific latest version from 6.x line that works