### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Follow these [instructions](docs/local-cluster.md) in order to create a local Op
   # Grant Jenkins Access to Projects
   oc policy add-role-to-group edit system:serviceaccounts:cicd -n dev
   oc policy add-role-to-group edit system:serviceaccounts:cicd -n stage
+  oc policy add-role-to-group edit system:serviceaccounts:cicd -n cicd
   ```  
 
 And then deploy the demo:

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -154,6 +154,7 @@ function deploy() {
 
   oc $ARG_OC_OPS policy add-role-to-group edit system:serviceaccounts:cicd-$PRJ_SUFFIX -n dev-$PRJ_SUFFIX
   oc $ARG_OC_OPS policy add-role-to-group edit system:serviceaccounts:cicd-$PRJ_SUFFIX -n stage-$PRJ_SUFFIX
+  oc $ARG_OC_OPS policy add-role-to-group edit system:serviceaccounts:cicd-$PRJ_SUFFIX -n cicd-$PRJ_SUFFIX
 
   if [ $LOGGEDIN_USER == 'system:admin' ] ; then
     oc $ARG_OC_OPS adm policy add-role-to-user admin $ARG_USERNAME -n dev-$PRJ_SUFFIX >/dev/null 2>&1


### PR DESCRIPTION
Granted Jenkins Access to "cicd" project with serviceaccount
This fixes the image build failure issue.

ERROR: Error running start-build on at least one item: [buildconfig/tasks];
{reference={}, err=Uploading file "target/ROOT.war" as binary input for the build ...
Error from server (NotFound): buildconfigs.build.openshift.io "tasks" not found, verb=start-build, cmd=oc --server=https://172.30.0.1:443 --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --namespace=dev --token=XXXXX start-build buildconfig/tasks --from-file=target/ROOT.war --wait=true -o=name , out=, status=1}

Finished: FAILURE