### PR TITLE
Add missing Jenkins step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ And then deploy the demo:
 
   ```
   # Deploy Demo
+  oc new-app jenkins-ephemeral -n cicd  
   oc new-app -n cicd -f cicd-template.yaml
   ```
 


### PR DESCRIPTION
Missing instruction step to deploy Jenkins for manual deployment.